### PR TITLE
Feature/TP-3127-llm-instance-should-be-configured-by-env-variable

### DIFF
--- a/LangChain/README.md
+++ b/LangChain/README.md
@@ -40,7 +40,7 @@ python -m pip install langchain-timbr
 ### One of: openai, anthropic, google, azure_openai, snowflake, databricks (or 'all')
 
 ```bash
-python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space]'
+python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space>]'
 ```
 
 ## Configuration
@@ -50,7 +50,7 @@ All chains, agents, and nodes support optional environment-based configuration. 
 ### Timbr Connection Parameters
 - **TIMBR_URL**: Default Timbr server URL
 - **TIMBR_TOKEN**: Default Timbr authentication token  
-- **TIMBR_ONTOLOGY** or **ONTOLOGY**: Default ontology/knowledge graph name
+- **TIMBR_ONTOLOGY**: Default ontology/knowledge graph name
 
 When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all chain and agent constructors and will use the environment values as defaults.
 
@@ -180,7 +180,7 @@ Create a Timbr SQL agent that wraps the pipeline to identify the relevant concep
 | **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
-| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -208,11 +208,11 @@ from langchain_timbr import TimbrSqlAgent
 
 agent = TimbrSqlAgent(
     # llm is optional if LLM environment variables are set
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders","Customers"],  # optional
@@ -250,9 +250,9 @@ from langchain_timbr import create_timbr_sql_agent
 agent_executor = create_timbr_sql_agent(
     llm=<llm>,                     # optional - if not provided, uses LlmWrapper with environment variables
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders","Customers"],  # optional
@@ -280,7 +280,7 @@ Returns the suggested concept to query based on the user question.
 | **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
-| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` environment variable. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
 | **views_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of views/cubes to include (List of strings, or a string of view/cube names divided by comma).<br />- If None, empty or '*', all available views/cubes are used.<br />- If populated, only those views/cubes will be included in query generation.<br />- If 'none' or 'null', no views/cubes will be used for the query. |
 | **include_logic_concepts** | bool<br />Default: False<br />**Optional** | Whether to include logic concepts (concepts without unique properties which only inherit from an upper level concept with filter logic) in the query.<br />*Note: This parameter has no effect when `concepts_list` is provided.* |
@@ -298,11 +298,11 @@ from langchain_timbr import IdentifyTimbrConceptChain
 
 identify_timbr_concept_chain = IdentifyTimbrConceptChain(
     # llm is optional if LLM environment variables are set
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     concepts_list=["Sales","Orders"],  # optional
     views_list=["sales_view"],         # optional
     note="Focus on last month's data"  # optional
@@ -330,7 +330,7 @@ Returns the suggested SQL based on the user question.
 | **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
-| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -354,11 +354,11 @@ from langchain_timbr import GenerateTimbrSqlChain
 
 generate_timbr_sql_chain = GenerateTimbrSqlChain(
     # llm is optional if LLM environment variables are set
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",      # optional
     concept="Sales",      # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -390,7 +390,7 @@ Validates the timbr SQL and re-generate a new one if necessary based on the user
 | **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
-| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **retries** | int<br />Default: 2<br />**Optional** | Number of retry attempts if the generated SQL is invalid. |
@@ -412,11 +412,11 @@ Validates the timbr SQL and re-generate a new one if necessary based on the user
 from langchain_timbr import ValidateTimbrSqlChain
 
 validate_timbr_sql_chain = ValidateTimbrSqlChain(
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -455,7 +455,7 @@ Calls the Generate SQL Chain and executes the query in timbr. Returns the query 
 | **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
-| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -480,11 +480,11 @@ Calls the Generate SQL Chain and executes the query in timbr. Returns the query 
 from langchain_timbr import ExecuteTimbrQueryChain
 
 execute_timbr_query_chain = ExecuteTimbrQueryChain(
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional:  uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",              # optional
     concept="Sales",              # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -529,10 +529,10 @@ Generates answer based on the prompt and query results.
 from langchain_timbr import GenerateAnswerChain
 
 generate_answer_chain = GenerateAnswerChain(
-    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=<llm>,  # optional:  uses LlmWrapper with env vars if not specified
     # url, token are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    url="https://your-timbr-app.com/",  # optional:  uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional:  uses TIMBR_TOKEN if not specified
 )
 
 answer_result = generate_answer_chain.invoke({

--- a/LangChain/README.md
+++ b/LangChain/README.md
@@ -36,9 +36,28 @@ To use this SDK, ensure you have the following:
 python -m pip install langchain-timbr
 ```
 
-## Install with selected LLM providers (One of: openai,anthropic,google,snowflake)
+## Install with selected LLM providers
+### One of: openai, anthropic, google, azure_openai, snowflake, databricks (or 'all')
+
 ```bash
 python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space]'
+```
+
+## Configuration
+
+All chains, agents, and nodes support environment-based configuration. You can set the following environment variables to provide default values:
+
+- **TIMBR_URL**: Default Timbr server URL
+- **TIMBR_TOKEN**: Default Timbr authentication token  
+- **TIMBR_ONTOLOGY** or **ONTOLOGY**: Default ontology/knowledge graph name
+
+When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all chain and agent constructors and will use the environment values as defaults.
+
+Example environment setup:
+```bash
+export TIMBR_URL="https://your-timbr-app.com/"
+export TIMBR_TOKEN="tk_XXXXXXXXXXXXXXXXXXXXXXXX"
+export TIMBR_ONTOLOGY="timbr_knowledge_graph"
 ```
 
 ## Features
@@ -76,6 +95,10 @@ You can launch the interactive Streamlit app to try out natural language queries
 ### 1. Initialize LLM instance
 
 ```python
+# Using env variables configurations
+from langchain_timbr import LlmWrapper
+llm = LlmWrapper()
+
 # Using OpenAI provider:
 from langchain_openai import ChatOpenAI
 llm = ChatOpenAI(
@@ -128,7 +151,7 @@ error = result.get("error", None)
 
 ## LangChain interface
 
-### Timbr SQL Agent 
+### Timbr SQL Agent
 
 Create a Timbr SQL agent that wraps the pipeline to identify the relevant concept and generate the SQL query over the ontology.
 
@@ -137,9 +160,9 @@ Create a Timbr SQL agent that wraps the pipeline to identify the relevant concep
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -167,9 +190,10 @@ from langchain_timbr import TimbrSqlAgent
 
 agent = TimbrSqlAgent(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders","Customers"],  # optional
@@ -234,9 +258,9 @@ Returns the suggested concept to query based on the user question.
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
 | **views_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of views/cubes to include (List of strings, or a string of view/cube names divided by comma).<br />- If None, empty or '*', all available views/cubes are used.<br />- If populated, only those views/cubes will be included in query generation.<br />- If 'none' or 'null', no views/cubes will be used for the query. |
 | **include_logic_concepts** | bool<br />Default: False<br />**Optional** | Whether to include logic concepts (concepts without unique properties which only inherit from an upper level concept with filter logic) in the query.<br />*Note: This parameter has no effect when `concepts_list` is provided.* |
@@ -254,9 +278,10 @@ from langchain_timbr import IdentifyTimbrConceptChain
 
 identify_timbr_concept_chain = IdentifyTimbrConceptChain(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     concepts_list=["Sales","Orders"],  # optional
     views_list=["sales_view"],         # optional
     note="Focus on last month's data"  # optional
@@ -282,9 +307,9 @@ Returns the suggested SQL based on the user question.
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -308,9 +333,10 @@ from langchain_timbr import GenerateTimbrSqlChain
 
 generate_timbr_sql_chain = GenerateTimbrSqlChain(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",      # optional
     concept="Sales",      # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -340,9 +366,9 @@ Validates the timbr SQL and re-generate a new one if necessary based on the user
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **retries** | int<br />Default: 2<br />**Optional** | Number of retry attempts if the generated SQL is invalid. |
@@ -365,9 +391,10 @@ from langchain_timbr import ValidateTimbrSqlChain
 
 validate_timbr_sql_chain = ValidateTimbrSqlChain(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -404,9 +431,9 @@ Calls the Generate SQL Chain and executes the query in timbr. Returns the query 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -432,9 +459,10 @@ from langchain_timbr import ExecuteTimbrQueryChain
 
 execute_timbr_query_chain = ExecuteTimbrQueryChain(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",              # optional
     concept="Sales",              # optional
     concepts_list=["Sales","Orders"],  # optional
@@ -468,8 +496,8 @@ Generates answer based on the prompt and query results.
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **verify_ssl** | bool<br />Default: True<br />**Optional** | Whether to verify SSL certificates. |
 | **is_jwt** | bool<br />Default: False<br />**Optional** | Whether to use JWT authentication. |
 | **jwt_tenant_id** | str<br />Default: None<br />**Optional** | Tenant ID for JWT authentication (if applicable). |
@@ -480,8 +508,9 @@ from langchain_timbr import GenerateAnswerChain
 
 generate_answer_chain = GenerateAnswerChain(
     llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
+    # url, token are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
 )
 
 answer_result = generate_answer_chain.invoke({

--- a/LangChain/README.md
+++ b/LangChain/README.md
@@ -45,19 +45,37 @@ python -m pip install 'langchain-timbr[<your selected providers, separated by co
 
 ## Configuration
 
-All chains, agents, and nodes support environment-based configuration. You can set the following environment variables to provide default values:
+All chains, agents, and nodes support optional environment-based configuration. You can set the following environment variables to provide default values and have easy setup for the provided tools:
 
+### Timbr Connection Parameters
 - **TIMBR_URL**: Default Timbr server URL
 - **TIMBR_TOKEN**: Default Timbr authentication token  
 - **TIMBR_ONTOLOGY** or **ONTOLOGY**: Default ontology/knowledge graph name
 
 When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all chain and agent constructors and will use the environment values as defaults.
 
+### LLM Configuration Parameters
+- **LLM_TYPE**: The type of LLM provider (One of langchain_timbr LlmTypes enum: 'openai-chat', 'anthropic-chat', 'chat-google-generative-ai', 'azure-openai-chat', 'snowflake-cortex', 'chat-databricks')
+- **LLM_API_KEY**: The API key for authenticating with the LLM provider
+- **LLM_MODEL**: The model name or deployment to use
+- **LLM_TEMPERATURE**: Temperature setting for the LLM
+- **LLM_ADDITIONAL_PARAMS**: Additional parameters as dict or JSON string
+
+When LLM environment variables are set, the `llm` parameter becomes optional and will use the `LlmWrapper` with environment configuration.
+
 Example environment setup:
 ```bash
+# Timbr connection
 export TIMBR_URL="https://your-timbr-app.com/"
 export TIMBR_TOKEN="tk_XXXXXXXXXXXXXXXXXXXXXXXX"
 export TIMBR_ONTOLOGY="timbr_knowledge_graph"
+
+# LLM configuration
+export LLM_TYPE="openai-chat"
+export LLM_API_KEY="your-openai-api-key"
+export LLM_MODEL="gpt-4o"
+export LLM_TEMPERATURE="0.1"
+export LLM_ADDITIONAL_PARAMS='{"max_tokens": 1000}'
 ```
 
 ## Features
@@ -159,7 +177,7 @@ Create a Timbr SQL agent that wraps the pipeline to identify the relevant concep
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -189,7 +207,8 @@ Create a Timbr SQL agent that wraps the pipeline to identify the relevant concep
 from langchain_timbr import TimbrSqlAgent
 
 agent = TimbrSqlAgent(
-    llm=<llm>,
+    # llm is optional if LLM environment variables are set
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -229,10 +248,11 @@ generate_sql_usage = usage_metadata.get('generate_sql', {})
 from langchain_timbr import create_timbr_sql_agent
 
 agent_executor = create_timbr_sql_agent(
-    llm=<llm>,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    llm=<llm>,                     # optional - if not provided, uses LlmWrapper with environment variables
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",               # optional
     concept="Sales",               # optional
     concepts_list=["Sales","Orders","Customers"],  # optional
@@ -257,7 +277,7 @@ Returns the suggested concept to query based on the user question.
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -277,7 +297,8 @@ Returns the suggested concept to query based on the user question.
 from langchain_timbr import IdentifyTimbrConceptChain
 
 identify_timbr_concept_chain = IdentifyTimbrConceptChain(
-    llm=<llm>,
+    # llm is optional if LLM environment variables are set
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -306,7 +327,7 @@ Returns the suggested SQL based on the user question.
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -332,7 +353,8 @@ Returns the suggested SQL based on the user question.
 from langchain_timbr import GenerateTimbrSqlChain
 
 generate_timbr_sql_chain = GenerateTimbrSqlChain(
-    llm=<llm>,
+    # llm is optional if LLM environment variables are set
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -365,7 +387,7 @@ Validates the timbr SQL and re-generate a new one if necessary based on the user
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -390,7 +412,7 @@ Validates the timbr SQL and re-generate a new one if necessary based on the user
 from langchain_timbr import ValidateTimbrSqlChain
 
 validate_timbr_sql_chain = ValidateTimbrSqlChain(
-    llm=<llm>,
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -430,7 +452,7 @@ Calls the Generate SQL Chain and executes the query in timbr. Returns the query 
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -458,7 +480,7 @@ Calls the Generate SQL Chain and executes the query in timbr. Returns the query 
 from langchain_timbr import ExecuteTimbrQueryChain
 
 execute_timbr_query_chain = ExecuteTimbrQueryChain(
-    llm=<llm>,
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -495,7 +517,7 @@ Generates answer based on the prompt and query results.
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **verify_ssl** | bool<br />Default: True<br />**Optional** | Whether to verify SSL certificates. |
@@ -507,7 +529,7 @@ Generates answer based on the prompt and query results.
 from langchain_timbr import GenerateAnswerChain
 
 generate_answer_chain = GenerateAnswerChain(
-    llm=<llm>,
+    llm=<llm>,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified

--- a/LangGraph/README.md
+++ b/LangGraph/README.md
@@ -39,9 +39,27 @@ To use this SDK, ensure you have the following:
 python -m pip install langchain-timbr
 ```
 
-## Install with selected LLM providers (One of: openai,anthropic,google,snowflake)
+## Install with selected LLM providers
+### One of: openai, anthropic, google, azure_openai, snowflake, databricks (or 'all')
 ```bash
 python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space]'
+```
+
+## Configuration
+
+All chains, agents, and nodes support environment-based configuration. You can set the following environment variables to provide default values:
+
+- **TIMBR_URL**: Default Timbr server URL
+- **TIMBR_TOKEN**: Default Timbr authentication token  
+- **TIMBR_ONTOLOGY** or **ONTOLOGY**: Default ontology/knowledge graph name
+
+When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all node constructors and will use the environment values as defaults.
+
+Example environment setup:
+```bash
+export TIMBR_URL="https://your-timbr-app.com/"
+export TIMBR_TOKEN="tk_XXXXXXXXXXXXXXXXXXXXXXXX"
+export TIMBR_ONTOLOGY="timbr_knowledge_graph"
 ```
 
 ## Directory Structure and Key Files
@@ -73,11 +91,14 @@ Wraps the **IdentifyTimbrConceptChain** functionality to identify the relevant c
 **Parameters:**
 
 | Parameter | Type / Default | Description |
+|-----------|----------------|----**Parameters:**
+
+| Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
 | **views_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of views/cubes to include (List of strings, or a string of view/cube names divided by comma).<br />- If None, empty or '*', all available views/cubes are used.<br />- If populated, only those views/cubes will be included in query generation.<br />- If 'none' or 'null', no views/cubes will be used for the query. |
 | **include_logic_concepts** | bool<br />Default: False<br />**Optional** | Whether to include logic concepts (concepts without unique properties which only inherit from an upper level concept with filter logic) in the query.<br />*Note: This parameter has no effect when `concepts_list` is provided.* |
@@ -98,9 +119,10 @@ from langchain_timbr import IdentifyConceptNode
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
 identify_node = IdentifyConceptNode(
     llm=llm_instance,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     concepts_list=["Sales", "Orders"],
     views_list=["sales_view"]
 )
@@ -121,9 +143,9 @@ Wraps the **GenerateTimbrSqlChain** functionality to generate SQL from a natural
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -150,9 +172,10 @@ from langchain_timbr import GenerateTimbrSqlNode
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
 generate_sql_node = GenerateTimbrSqlNode(
     llm=llm_instance,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales"
 )
@@ -173,9 +196,9 @@ Wraps the **ValidateTimbrSqlChain** functionality to validate (and optionally ad
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **retries** | int<br />Default: 2<br />**Optional** | Number of retry attempts if the generated SQL is invalid. |
@@ -201,9 +224,10 @@ from langchain_timbr import ValidateSemanticSqlNode
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
 validate_sql_node = ValidateSemanticSqlNode(
     llm=llm_instance,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales",
     retries=3
@@ -226,9 +250,9 @@ Wraps the **ExecuteTimbrQueryChain** functionality to execute the generated SQL 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
-| **ontology** | str<br />**Required** | Name of the ontology/knowledge graph. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
+| **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
 | **schema** | str<br />Default: None<br />**Optional** | Name of the schema to query. |
 | **concept** | str<br />Default: None<br />**Optional** | Name of a specific concept to query. |
 | **concepts_list** | List[str] or str<br />Default: None<br />**Optional** | Collection of concepts to include (List of strings, or a string of concept names divided by comma).<br />- If None, empty or '*', all available concepts are used.<br />- If populated, only those concepts will be included in query generation.<br />- If 'none' or 'null', no concepts will be used for the query. |
@@ -257,9 +281,10 @@ from langchain_timbr import ExecuteSemanticQueryNode
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
 execute_query_node = ExecuteSemanticQueryNode(
     llm=llm_instance,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
-    ontology="timbr_knowledge_graph",
+    # url, token, ontology are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales"
 )
@@ -280,8 +305,8 @@ Wraps the **GenerateAnswerChain** functionality to answer based on the prompt an
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
 | **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
-| **url** | str<br />**Required** | Timbr server URL. |
-| **token** | str<br />**Required** | Timbr authentication token. |
+| **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
+| **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **verify_ssl** | bool<br />Default: True<br />**Optional** | Whether to verify SSL certificates. |
 | **is_jwt** | bool<br />Default: False<br />**Optional** | Whether to use JWT authentication. |
 | **jwt_tenant_id** | str<br />Default: None<br />**Optional** | Tenant ID for JWT authentication (if applicable). |
@@ -295,8 +320,9 @@ from langchain_timbr import GenerateResponseNode
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
 response_node = GenerateResponseNode(
     llm=llm_instance,
-    url="https://your-timbr-app.com/",
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",
+    # url, token are optional if environment variables are set
+    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
 )
 
 state = StateGraph()
@@ -307,12 +333,30 @@ state.concept = "Sales"
 state.rows = [{"total_sales": 1250000}]
 
 output = response_node(state)
-print("Final Response:", output["response"])
+print("Generated Response:", output)
 ```
 
-## Examples
+## Environment-Based Usage Examples
 
-- **LangGraph Nodes**: Use `GenerateTimbrSqlNode` and `ExecuteTimbrQueryNode` & more, for more granular control.
+When environment variables are properly configured, you can simplify node creation:
+
+```python
+# With environment variables set (TIMBR_URL, TIMBR_TOKEN, TIMBR_ONTOLOGY)
+# you can create nodes with minimal parameters
+
+llm_instance = <your_llm_instance>
+
+# Simplified node creation - uses environment variables
+identify_node = IdentifyConceptNode(llm=llm_instance)
+generate_sql_node = GenerateTimbrSqlNode(llm=llm_instance)
+validate_sql_node = ValidateSemanticSqlNode(llm=llm_instance)
+execute_query_node = ExecuteSemanticQueryNode(llm=llm_instance)
+response_node = GenerateResponseNode(llm=llm_instance)
+```
+
+This approach is ideal for production environments where connection parameters are managed through environment configuration.
+
+You can also use these powerful foundational building blocks like `GenerateTimbrSqlNode` and `ExecuteTimbrQueryNode` & more, for more granular control.
 
 ## Timbr Methods Overview
 

--- a/LangGraph/README.md
+++ b/LangGraph/README.md
@@ -42,7 +42,7 @@ python -m pip install langchain-timbr
 ## Install with selected LLM providers
 ### One of: openai, anthropic, google, azure_openai, snowflake, databricks (or 'all')
 ```bash
-python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space]'
+python -m pip install 'langchain-timbr[<your selected providers, separated by comma w/o space>]'
 ```
 
 ## Configuration
@@ -133,11 +133,11 @@ from langchain_timbr import IdentifyConceptNode
 
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 identify_node = IdentifyConceptNode(
-    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=llm_instance,  # optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     concepts_list=["Sales", "Orders"],
     views_list=["sales_view"]
 )
@@ -186,11 +186,11 @@ from langchain_timbr import GenerateTimbrSqlNode
 
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 generate_sql_node = GenerateTimbrSqlNode(
-    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=llm_instance,  # optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales"
 )
@@ -238,11 +238,11 @@ from langchain_timbr import ValidateSemanticSqlNode
 
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 validate_sql_node = ValidateSemanticSqlNode(
-    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=llm_instance,  # optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales",
     retries=3
@@ -295,11 +295,11 @@ from langchain_timbr import ExecuteSemanticQueryNode
 
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 execute_query_node = ExecuteSemanticQueryNode(
-    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=llm_instance,  # optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
-    ontology="timbr_knowledge_graph",  # Optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
+    url="https://your-timbr-app.com/",  # optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional: uses TIMBR_TOKEN if not specified
+    ontology="timbr_knowledge_graph",  # optional: uses TIMBR_ONTOLOGY/ONTOLOGY if not specified
     schema="dtimbr",
     concept="Sales"
 )
@@ -334,10 +334,10 @@ from langchain_timbr import GenerateResponseNode
 
 llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 response_node = GenerateResponseNode(
-    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
+    llm=llm_instance,  # optional: uses LlmWrapper with env vars if not specified
     # url, token are optional if environment variables are set
-    url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
-    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
+    url="https://your-timbr-app.com/",  # optional: uses TIMBR_URL if not specified
+    token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # optional: uses TIMBR_TOKEN if not specified
 )
 
 state = StateGraph()

--- a/LangGraph/README.md
+++ b/LangGraph/README.md
@@ -47,19 +47,37 @@ python -m pip install 'langchain-timbr[<your selected providers, separated by co
 
 ## Configuration
 
-All chains, agents, and nodes support environment-based configuration. You can set the following environment variables to provide default values:
+All chains, agents, and nodes support optional environment-based configuration. You can set the following environment variables to provide default values and have easy setup for the provided tools:
 
+**Timbr Connection Variables:**
 - **TIMBR_URL**: Default Timbr server URL
 - **TIMBR_TOKEN**: Default Timbr authentication token  
 - **TIMBR_ONTOLOGY** or **ONTOLOGY**: Default ontology/knowledge graph name
 
-When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all node constructors and will use the environment values as defaults.
+When these environment variables are set, the corresponding parameters (`url`, `token`, `ontology`) become optional in all chain and agent constructors and will use the environment values as defaults.
+
+**LLM Configuration Variables:**
+- **LLM_TYPE**: Type of LLM to use (e.g., "openai", "anthropic", "azure_openai", "google", "snowflake", "databricks", "timbr")
+- **LLM_API_KEY**: API key for the LLM provider
+- **LLM_MODEL**: Model name to use (e.g., "gpt-4o", "claude-3-5-sonnet-20241022")
+- **LLM_TEMPERATURE**: Temperature setting for the LLM (default: 0.1)
+- **LLM_ADDITIONAL_PARAMS**: Additional parameters as JSON string (e.g., '{"max_tokens": 1000}')
+
+When LLM environment variables are set, the `llm` parameter becomes optional and will use the `LlmWrapper` with environment configuration.
 
 Example environment setup:
 ```bash
+# Timbr connection
 export TIMBR_URL="https://your-timbr-app.com/"
 export TIMBR_TOKEN="tk_XXXXXXXXXXXXXXXXXXXXXXXX"
 export TIMBR_ONTOLOGY="timbr_knowledge_graph"
+
+# LLM configuration
+export LLM_TYPE="openai-chat"
+export LLM_API_KEY="your-openai-api-key"
+export LLM_MODEL="gpt-4o"
+export LLM_TEMPERATURE="0.1"
+export LLM_ADDITIONAL_PARAMS='{"max_tokens": 1000}'
 ```
 
 ## Directory Structure and Key Files
@@ -91,11 +109,8 @@ Wraps the **IdentifyTimbrConceptChain** functionality to identify the relevant c
 **Parameters:**
 
 | Parameter | Type / Default | Description |
-|-----------|----------------|----**Parameters:**
-
-| Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -116,9 +131,9 @@ Wraps the **IdentifyTimbrConceptChain** functionality to identify the relevant c
 from langgraph.graph import StateGraph
 from langchain_timbr import IdentifyConceptNode
 
-llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
+llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 identify_node = IdentifyConceptNode(
-    llm=llm_instance,
+    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -142,7 +157,7 @@ Wraps the **GenerateTimbrSqlChain** functionality to generate SQL from a natural
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -169,9 +184,9 @@ Wraps the **GenerateTimbrSqlChain** functionality to generate SQL from a natural
 from langgraph.graph import StateGraph
 from langchain_timbr import GenerateTimbrSqlNode
 
-llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
+llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 generate_sql_node = GenerateTimbrSqlNode(
-    llm=llm_instance,
+    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -195,7 +210,7 @@ Wraps the **ValidateTimbrSqlChain** functionality to validate (and optionally ad
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -221,9 +236,9 @@ Wraps the **ValidateTimbrSqlChain** functionality to validate (and optionally ad
 from langgraph.graph import StateGraph
 from langchain_timbr import ValidateSemanticSqlNode
 
-llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
+llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 validate_sql_node = ValidateSemanticSqlNode(
-    llm=llm_instance,
+    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -249,7 +264,7 @@ Wraps the **ExecuteTimbrQueryChain** functionality to execute the generated SQL 
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **ontology** | str<br />Default: None<br />**Optional** | Name of the ontology/knowledge graph. If None, uses the value from the `TIMBR_ONTOLOGY` or `ONTOLOGY` environment variable. |
@@ -278,9 +293,9 @@ Wraps the **ExecuteTimbrQueryChain** functionality to execute the generated SQL 
 from langgraph.graph import StateGraph
 from langchain_timbr import ExecuteSemanticQueryNode
 
-llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
+llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 execute_query_node = ExecuteSemanticQueryNode(
-    llm=llm_instance,
+    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token, ontology are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -304,7 +319,7 @@ Wraps the **GenerateAnswerChain** functionality to answer based on the prompt an
 
 | Parameter | Type / Default | Description |
 |-----------|----------------|-------------|
-| **llm** | LLM<br />**Required** | Language model instance (or a function taking a prompt string and returning an LLM's response). |
+| **llm** | LLM<br />Default: None<br />**Optional** | Language model instance (or a function taking a prompt string and returning an LLM's response). If None, uses `LlmWrapper` with environment variables. |
 | **url** | str<br />Default: None<br />**Optional** | Timbr server URL. If None, uses the value from the `TIMBR_URL` environment variable. |
 | **token** | str<br />Default: None<br />**Optional** | Timbr authentication token. If None, uses the value from the `TIMBR_TOKEN` environment variable. |
 | **verify_ssl** | bool<br />Default: True<br />**Optional** | Whether to verify SSL certificates. |
@@ -317,9 +332,9 @@ Wraps the **GenerateAnswerChain** functionality to answer based on the prompt an
 from langgraph.graph import StateGraph
 from langchain_timbr import GenerateResponseNode
 
-llm_instance = <your_llm_instance>  # Replace with your actual LLM instance
+llm_instance = <your_llm_instance>  # Replace with your actual LLM instance (optional)
 response_node = GenerateResponseNode(
-    llm=llm_instance,
+    llm=llm_instance,  # Optional: uses LlmWrapper with env vars if not specified
     # url, token are optional if environment variables are set
     url="https://your-timbr-app.com/",  # Optional: uses TIMBR_URL if not specified
     token="tk_XXXXXXXXXXXXXXXXXXXXXXXX",  # Optional: uses TIMBR_TOKEN if not specified
@@ -344,14 +359,22 @@ When environment variables are properly configured, you can simplify node creati
 # With environment variables set (TIMBR_URL, TIMBR_TOKEN, TIMBR_ONTOLOGY)
 # you can create nodes with minimal parameters
 
-llm_instance = <your_llm_instance>
+# Simplified node creation - uses timbr environment variables
+llm_instance = <your_llm_instance>  # Optional - can be omitted if LLM env vars are set
 
-# Simplified node creation - uses environment variables
 identify_node = IdentifyConceptNode(llm=llm_instance)
 generate_sql_node = GenerateTimbrSqlNode(llm=llm_instance)
 validate_sql_node = ValidateSemanticSqlNode(llm=llm_instance)
 execute_query_node = ExecuteSemanticQueryNode(llm=llm_instance)
 response_node = GenerateResponseNode(llm=llm_instance)
+
+
+# Simplified node creation - uses llm & timbr environment variables
+identify_node = IdentifyConceptNode()
+generate_sql_node = GenerateTimbrSqlNode()
+validate_sql_node = ValidateSemanticSqlNode()
+execute_query_node = ExecuteSemanticQueryNode()
+response_node = GenerateResponseNode()
 ```
 
 This approach is ideal for production environments where connection parameters are managed through environment configuration.


### PR DESCRIPTION
As a user who uses langchain-timbr, I would like to have an easy setup using Timbr Chains/Nodes/Agents.

For that, I want to be able to configure the LLM instance using environment variables instead of manually initiating it and passing it every time.